### PR TITLE
Remove ALPN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV MIRROR https://www-eu.apache.org/dist/jmeter/binaries
 ENV JMETER_VERSION 5.3
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
 ENV JMETER_BIN ${JMETER_HOME}/bin
-ENV ALPN_VERSION 8.1.13.v20181017
 ENV PATH ${JMETER_BIN}:$PATH
 COPY entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh \
@@ -32,10 +31,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh \
  && sed -i '/PrintGCDetails/s/^# /: "${/g' ${JMETER_BIN}/jmeter && sed -i '/PrintGCDetails/s/$/}"/g' ${JMETER_BIN}/jmeter \
  && chmod +x ${JMETER_HOME}/bin/*.sh \
  && jmeter --version \
- && curl --location --silent --show-error --output /opt/alpn-boot-${ALPN_VERSION}.jar https://repo1.maven.org/maven2/org/mortbay/jetty/alpn/alpn-boot/${ALPN_VERSION}/alpn-boot-${ALPN_VERSION}.jar \
  && rm -fr /tmp/*
-# Required for HTTP2 plugins
-ENV JVM_ARGS -Xbootclasspath/p:/opt/alpn-boot-${ALPN_VERSION}.jar
 WORKDIR /jmeter
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["jmeter", "--?"]


### PR DESCRIPTION
ALPN APIs have been backported from Java 9 to OpenJDK 8u252. there is no more need for the Jetty ALPN boot jar 

See [here](https://github.com/jetty-project/jetty-alpn#jetty-alpn)